### PR TITLE
Improve Streamlit workflow and add Outlook features

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ Run the Streamlit application:
 streamlit run app.py
 ```
 
+The app now includes a **Workflow** dashboard summarising the notebooks,
+a **Play** tab for generating and sending emails through Outlook, and a
+template manager backed by SharePoint.
+
 ## Outlook Integration and API Key
 
 Integration with Microsoft Outlook is handled through the Microsoft Graph API.

--- a/app.py
+++ b/app.py
@@ -1,4 +1,4 @@
 import streamlit as st
 
-# Redirect to the Learn page by default
-st.switch_page("pages/2_Learn.py")
+# Redirect to the Workflow page by default
+st.switch_page("pages/1_Workflow.py")

--- a/docs/outlook_integration.md
+++ b/docs/outlook_integration.md
@@ -1,6 +1,6 @@
 # Outlook Integration
 
-This project can send emails using Microsoft Graph. Provide credentials as environment variables:
+This project can send emails using Microsoft Graph. Set the following environment variables so the helper functions can authenticate without prompting:
 
 - `OUTLOOK_CLIENT_ID`
 - `OUTLOOK_TENANT_ID`

--- a/email_generator/outlook_integration.py
+++ b/email_generator/outlook_integration.py
@@ -1,28 +1,4 @@
-
-"""Basic Outlook integration via Microsoft Graph API."""
-
-from __future__ import annotations
-
-import requests
-import msal
-
-GRAPH_SCOPE = ["https://graph.microsoft.com/.default"]
-GRAPH_ENDPOINT = "https://graph.microsoft.com/v1.0"
-
-
-def get_access_token(client_id: str, client_secret: str, tenant_id: str) -> str:
-    """Acquire an app-only access token for Microsoft Graph."""
-    app = msal.ConfidentialClientApplication(
-        client_id=client_id,
-        client_credential=client_secret,
-        authority=f"https://login.microsoftonline.com/{tenant_id}",
-    )
-    result = app.acquire_token_for_client(scopes=GRAPH_SCOPE)
-    if "access_token" not in result:
-        raise RuntimeError(result.get("error_description", "No token received"))
-
-"""Utility functions for sending email via Microsoft Graph."""
-
+"""Outlook helpers using Microsoft Graph."""
 from __future__ import annotations
 
 import os
@@ -31,14 +7,14 @@ from typing import Optional
 import msal
 import requests
 
+GRAPH_ENDPOINT = "https://graph.microsoft.com/v1.0"
+SCOPES = ["https://graph.microsoft.com/.default"]
 
 CLIENT_ID = os.getenv("OUTLOOK_CLIENT_ID")
 TENANT_ID = os.getenv("OUTLOOK_TENANT_ID")
 CLIENT_SECRET = os.getenv("OUTLOOK_CLIENT_SECRET")
 SENDER_ADDRESS = os.getenv("OUTLOOK_SENDER")
-
 AUTHORITY_TEMPLATE = "https://login.microsoftonline.com/{tenant_id}"
-SCOPES = ["https://graph.microsoft.com/.default"]
 
 
 def get_access_token(
@@ -46,14 +22,13 @@ def get_access_token(
     client_secret: Optional[str] = None,
     tenant_id: Optional[str] = None,
 ) -> str:
-    """Acquire an access token for the Microsoft Graph API using client credentials."""
-
+    """Return an access token for Microsoft Graph."""
     client_id = client_id or CLIENT_ID
     tenant_id = tenant_id or TENANT_ID
     client_secret = client_secret or CLIENT_SECRET
 
     if not all([client_id, tenant_id, client_secret]):
-        raise ValueError("Client ID, tenant ID, and client secret are required")
+        raise ValueError("Client ID, tenant ID and client secret are required")
 
     app = msal.ConfidentialClientApplication(
         client_id,
@@ -64,45 +39,13 @@ def get_access_token(
     result = app.acquire_token_silent(SCOPES, account=None)
     if not result:
         result = app.acquire_token_for_client(scopes=SCOPES)
-
     if "access_token" not in result:
         error = result.get("error_description", "Unknown error")
         raise RuntimeError(f"Failed to obtain access token: {error}")
-
-
     return result["access_token"]
 
 
 def send_email(
-
-    token: str,
-    from_user: str,
-    recipient: str,
-    subject: str,
-    body_html: str,
-) -> None:
-    """Send an email using Graph API.
-
-    Parameters
-    ----------
-    token:
-        OAuth access token.
-    from_user:
-        User ID or email address of the sending account.
-    recipient:
-        Email address of the recipient.
-    subject:
-        Subject line of the message.
-    body_html:
-        HTML body of the email.
-    """
-    url = f"{GRAPH_ENDPOINT}/users/{from_user}/sendMail"
-    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
-    payload = {
-        "message": {
-            "subject": subject,
-            "body": {"contentType": "HTML", "content": body_html},
-
     recipient: str,
     subject: str,
     body: str,
@@ -112,22 +55,7 @@ def send_email(
     client_secret: Optional[str] = None,
     tenant_id: Optional[str] = None,
 ) -> None:
-    """Send an email via Microsoft Graph.
-
-    Parameters
-    ----------
-    recipient:
-        Email address to send to.
-    subject:
-        Email subject line.
-    body:
-        HTML body content.
-    sender:
-        The address of the sending account. Defaults to ``OUTLOOK_SENDER`` env.
-    client_id, client_secret, tenant_id:
-        Optional credentials overriding environment variables.
-    """
-
+    """Send an HTML email via Microsoft Graph."""
     sender = sender or SENDER_ADDRESS
     if not sender:
         raise ValueError("Sender email address must be provided")
@@ -140,22 +68,15 @@ def send_email(
         "Authorization": f"Bearer {token}",
         "Content-Type": "application/json",
     }
-
     message = {
         "message": {
             "subject": subject,
             "body": {"contentType": "HTML", "content": body},
-
             "toRecipients": [{"emailAddress": {"address": recipient}}],
         },
         "saveToSentItems": "true",
     }
-
-    response = requests.post(url, headers=headers, json=payload, timeout=10)
-
-
-    endpoint = f"https://graph.microsoft.com/v1.0/users/{sender}/sendMail"
+    endpoint = f"{GRAPH_ENDPOINT}/users/{sender}/sendMail"
     response = requests.post(endpoint, headers=headers, json=message, timeout=10)
-
     response.raise_for_status()
 

--- a/pages/1_Workflow.py
+++ b/pages/1_Workflow.py
@@ -1,0 +1,45 @@
+import streamlit as st
+
+st.set_page_config(page_title="Workflow", layout="wide")
+
+st.title("📊 Project Workflow")
+
+st.markdown(
+    "This guided tour summarises the notebooks that train and evaluate the models"
+    " used for template generation. Each tab provides a short description so you"
+    " can follow the entire pipeline from data to email delivery."
+)
+
+steps = [
+    "Data Preparation",
+    "Model Training",
+    "Evaluation",
+    "Email Generation",
+]
+
+tabs = st.tabs(steps)
+
+with tabs[0]:
+    st.markdown(
+        "The *01_data_preprocessing* notebooks clean raw emails and extract fields."
+        " You can inspect them in the `notebooks/` folder."
+    )
+
+with tabs[1]:
+    st.markdown(
+        "The *03_model_training* notebooks fine‑tune language models on the"
+        " prepared dataset to learn common structures and tones."
+    )
+
+with tabs[2]:
+    st.markdown(
+        "The *04_model_evaluation* notebooks compare different runs and measure"
+        " how well the generated templates match expectations."
+    )
+
+with tabs[3]:
+    st.markdown(
+        "Use the **Play** tab to create templates and send them via Outlook."
+        " SharePoint integration lets you store reusable drafts."
+    )
+


### PR DESCRIPTION
## Summary
- clean up Outlook helper and expose simple `send_email`
- add Workflow dashboard to explain notebook steps
- extend Play page to send email via Outlook and save/load templates through SharePoint
- default app to new Workflow page
- document environment variables and new features

Codex was used to understand the repository, modify Streamlit pages, and run unit tests. The agent generated the code patches, executed `py_compile` and `pytest`, and produced this PR message automatically.

------
https://chatgpt.com/codex/tasks/task_e_68753e8ef70c8328afe1b079f5ab76b8