### PR TITLE
Set dark mode as default

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,1 +1,2 @@
-
+[theme]
+base = 'dark'


### PR DESCRIPTION
## Summary
- add a Streamlit config setting with the dark theme as default

Codex was used to edit the `.streamlit/config.toml` file and verify the changes by running the existing pytest suite. All tests pass as expected, demonstrating that the new configuration does not affect functional behavior.

------
https://chatgpt.com/codex/tasks/task_e_68755c893f608328bdd2585152058244