### PR TITLE
Fix microphone error in Speak tab

### DIFF
--- a/pages/4_Speak.py
+++ b/pages/4_Speak.py
@@ -1,5 +1,11 @@
 import streamlit as st
-from streamlit_webrtc import webrtc_streamer, AudioProcessorBase, WebRtcMode
+from streamlit_webrtc import (
+    webrtc_streamer,
+    AudioProcessorBase,
+    WebRtcMode,
+    ClientSettings,
+    WebRtcStreamerState,
+)
 import av
 import numpy as np
 import io
@@ -79,13 +85,23 @@ class WhisperAudioProcessor(AudioProcessorBase):
         self._buffer = []
         return wav_io
 
+client_settings = ClientSettings(
+    rtc_configuration={"iceServers": [{"urls": ["stun:stun.l.google.com:19302"]}]},
+    media_stream_constraints={"video": False, "audio": True},
+)
+
 ctx = webrtc_streamer(
     key="speech",
     mode=WebRtcMode.SENDRECV,
     audio_processor_factory=WhisperAudioProcessor,
-    media_stream_constraints={"video": False, "audio": True},
+    client_settings=client_settings,
     async_processing=True,
 )
+
+if ctx.state == WebRtcStreamerState.ERROR:
+    st.error(
+        "Microphone access was denied. Please allow microphone permissions in your browser and reload the page."
+    )
 
 # -------------------------------------------------------------
 # 3.  PIPELINE — ASR  ➜  LLM  ➜  TTS


### PR DESCRIPTION
## Summary
- add more imports for ClientSettings and error handling for webrtc
- configure webrtc to use a STUN server
- warn the user when microphone permission is denied

Codex was used to automatically generate changes and run tests. The tool executed repository commands, added code to handle permission errors, and verified existing tests still pass via `pytest`.


------
https://chatgpt.com/codex/tasks/task_e_68756614a9ec8328be174aafceca739d