### PR TITLE
Add prompt suggestions to Learn tab

### DIFF
--- a/pages/2_Learn.py
+++ b/pages/2_Learn.py
@@ -20,7 +20,26 @@ with col:
         st.warning("Please enter your OpenAI API key in the sidebar.")
         st.stop()
 
-    query = st.text_input("Ask something about the project...", placeholder="e.g. How does the email generation work?")
+    st.markdown("##### Try asking one of these:")
+
+    suggestions = [
+        "How do I set up the project locally?",
+        "What are the latest updates to the project?",
+        "How does the email generation work?",
+        "Where should I start exploring the code?",
+    ]
+
+    cols = st.columns(len(suggestions))
+    for col, prompt in zip(cols, suggestions):
+        if col.button(prompt, use_container_width=True):
+            st.session_state.learn_query = prompt
+            st.experimental_rerun()
+
+    query = st.text_input(
+        "Ask something about the project...",
+        placeholder="e.g. How does the email generation work?",
+        key="learn_query",
+    )
 
     if query:
         st.info("🔍 Thinking...")


### PR DESCRIPTION
## Summary
- add quick prompt suggestions to the Learn page

Codex was used to automatically apply the change and ensure tests ran before committing.


------
https://chatgpt.com/codex/tasks/task_e_687565eab85c83288952275cd125a075