### PR TITLE
Refine Play tab

### DIFF
--- a/pages/3_Play.py
+++ b/pages/3_Play.py
@@ -24,7 +24,7 @@ init_sidebar(
 _, col, _ = st.columns([1, 3, 1])
 
 with col:
-    st.title("📝 Generate an Email Template")
+    st.title("📝 Generate an Email Draft")
     st.markdown(
         "#### Paste an email you’ve received, or describe the situation. The AI will draft a reply for you."
     )
@@ -56,17 +56,6 @@ with col:
         "Email type", ["Reply", "Follow-up", "Request", "Information", "Other"]
     )
 
-    EXAMPLE_TEMPLATES = {
-        "Meeting Invitation": "Hi NAME,\n\nI'd like to invite you to a meeting on DATE at TIME to discuss our next steps.",
-        "Project Update": "Hello NAME,\n\nHere is a brief update on the project status...",
-        "Thank You": "Dear NAME,\n\nThank you for your assistance with the recent task."
-    }
-    example_choice = st.selectbox(
-        "Or pick an example template",
-        ["None"] + list(EXAMPLE_TEMPLATES.keys()),
-    )
-    if example_choice != "None":
-        st.session_state.generated_email = EXAMPLE_TEMPLATES[example_choice]
 
     # Generate button with streaming output
     if st.button("Generate Email"):


### PR DESCRIPTION
## Summary
- remove built-in template dropdown from **Play** tab
- retitle UI to "Generate an Email Draft"

Codex was used to modify the Streamlit page and to run the repository's tests. After the change, all tests pass.

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68756d6706c88328a84bdd69298d1412