### PR TITLE
Fix Learn tab syntax error

### DIFF
--- a/pages/2_Learn.py
+++ b/pages/2_Learn.py
@@ -28,10 +28,6 @@ with col:
         st.stop()
 
 
-    query = st.text_input(
-        "Ask something about the project...",
-        placeholder="e.g. How does the email generation work?",
-
     st.markdown("##### Try asking one of these:")
 
     suggestions = [


### PR DESCRIPTION
## Summary
- remove incomplete text input call from the Learn page

Codex was used to inspect the repository, run tests and ruff, and craft the patch.


------
https://chatgpt.com/codex/tasks/task_e_68756db2a2c88328b26cedefa1913132