### PR TITLE
Remove stray merge line from Speak page

### DIFF
--- a/pages/4_Speak.py
+++ b/pages/4_Speak.py
@@ -1,4 +1,3 @@
-
 import io
 import os
 import sys


### PR DESCRIPTION
## Summary
- fix stray merge line in `pages/4_Speak.py`

Codex was used to remove the leftover merge line and ensure the Speak tab loads correctly. Tests were executed via `pytest -q` to verify no regressions.


------
https://chatgpt.com/codex/tasks/task_e_68756d8c8a888328b80b243f0700a602